### PR TITLE
setting kibana to use a pid file, to avoid logrotation bugs

### DIFF
--- a/templates/default/kibana7.yml.erb
+++ b/templates/default/kibana7.yml.erb
@@ -58,7 +58,7 @@ elasticsearch.shardTimeout: 0
 # server.ssl.key: /path/to/your/server.crt
 
 # Set the path to where you would like the process id file to be created.
-# pid.file: /var/run/kibana.pid
+pid.file: /var/run/kibana.pid
 
 # If you would like to send the log output to a file you can set the path below.
 # This will also turn off the STDOUT log output.


### PR DESCRIPTION
This conversation explains why this change is necessary - https://discuss.elastic.co/t/kibana-logs-rotation/66441/2